### PR TITLE
feat: Add EKS cluster and security group Terraform modules

### DIFF
--- a/infra/terraform/environments/eks/main.tf
+++ b/infra/terraform/environments/eks/main.tf
@@ -1,0 +1,89 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    # Backend configuration is provided via -backend-config flags during init
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  common_tags = {
+    Environment = var.environment
+    Project     = var.project_name
+    ManagedBy   = "Terraform"
+  }
+}
+
+# Data source to get VPC info
+data "aws_vpc" "main" {
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+# Data source to get public subnet
+data "aws_subnet" "public" {
+  tags = {
+    Name = "${var.project_name}-public-subnet"
+  }
+}
+
+# Data source to get private EKS subnet
+data "aws_subnet" "eks" {
+  tags = {
+    Name = "${var.project_name}-private-eks"
+  }
+}
+
+# Security Group Module
+module "security_group" {
+  source = "../../modules/security_group"
+
+  project_name          = var.project_name
+  vpc_id                = data.aws_vpc.main.id
+  public_node_port_from = var.public_node_port_from
+  public_node_port_to   = var.public_node_port_to
+
+  tags = local.common_tags
+}
+
+# EKS Module
+module "eks" {
+  source = "../../modules/eks"
+
+  project_name                   = var.project_name
+  environment                    = var.environment
+  subnet_ids                     = [data.aws_subnet.public.id, data.aws_subnet.eks.id]
+  private_subnet_ids             = [data.aws_subnet.eks.id]
+  public_subnet_ids              = [data.aws_subnet.public.id]
+  cluster_security_group_id      = module.security_group.eks_cluster_security_group_id
+  private_node_security_group_id = module.security_group.eks_private_node_security_group_id
+  public_node_security_group_id  = module.security_group.eks_public_node_security_group_id
+  kubernetes_version             = var.kubernetes_version
+  node_instance_types            = var.node_instance_types
+  capacity_type                  = var.capacity_type
+
+  # Private node group scaling
+  private_node_desired_size = var.private_node_desired_size
+  private_node_min_size     = var.private_node_min_size
+  private_node_max_size     = var.private_node_max_size
+
+  # Public node group scaling
+  public_node_desired_size = var.public_node_desired_size
+  public_node_min_size     = var.public_node_min_size
+  public_node_max_size     = var.public_node_max_size
+
+  tags = local.common_tags
+
+  depends_on = [module.security_group]
+}

--- a/infra/terraform/environments/eks/outputs.tf
+++ b/infra/terraform/environments/eks/outputs.tf
@@ -1,0 +1,30 @@
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "EKS cluster endpoint"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  description = "EKS cluster certificate authority data"
+  value       = module.eks.cluster_certificate_authority_data
+  sensitive   = true
+}
+
+output "cluster_security_group_id" {
+  description = "EKS cluster security group ID"
+  value       = module.eks.cluster_security_group_id
+}
+
+output "node_security_group_id" {
+  description = "EKS node group security group ID"
+  value       = module.eks.node_security_group_id
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "EKS cluster OIDC issuer URL"
+  value       = module.eks.cluster_oidc_issuer_url
+}

--- a/infra/terraform/environments/eks/terraform.tfvars
+++ b/infra/terraform/environments/eks/terraform.tfvars
@@ -1,0 +1,18 @@
+aws_region          = "ap-northeast-1"
+environment         = "staging"
+project_name        = "andere-boxing"
+
+# EKS Configuration
+kubernetes_version  = "1.29"
+node_instance_types = ["t3.medium"]
+capacity_type       = "SPOT"  # ハッカソンなのでコスト削減のためSPOT
+
+# Private node group (2 nodes)
+private_node_desired_size = 2
+private_node_min_size     = 1
+private_node_max_size     = 3
+
+# Public node group (2 nodes)
+public_node_desired_size = 2
+public_node_min_size     = 1
+public_node_max_size     = 3

--- a/infra/terraform/environments/eks/variables.tf
+++ b/infra/terraform/environments/eks/variables.tf
@@ -1,0 +1,84 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version"
+  type        = string
+  default     = "1.29"
+}
+
+variable "node_instance_types" {
+  description = "Instance types for node group"
+  type        = list(string)
+  default     = ["t3.medium"]
+}
+
+variable "capacity_type" {
+  description = "Capacity type for node group (ON_DEMAND or SPOT)"
+  type        = string
+  default     = "ON_DEMAND"
+}
+
+# Private node group scaling
+variable "private_node_desired_size" {
+  description = "Desired number of private nodes"
+  type        = number
+  default     = 2
+}
+
+variable "private_node_min_size" {
+  description = "Minimum number of private nodes"
+  type        = number
+  default     = 1
+}
+
+variable "private_node_max_size" {
+  description = "Maximum number of private nodes"
+  type        = number
+  default     = 3
+}
+
+# Public node group scaling
+variable "public_node_desired_size" {
+  description = "Desired number of public nodes"
+  type        = number
+  default     = 2
+}
+
+variable "public_node_min_size" {
+  description = "Minimum number of public nodes"
+  type        = number
+  default     = 1
+}
+
+variable "public_node_max_size" {
+  description = "Maximum number of public nodes"
+  type        = number
+  default     = 3
+}
+
+# Public node security group ports
+variable "public_node_port_from" {
+  description = "Start port for public node ingress (UDP)"
+  type        = number
+  default     = 7000
+}
+
+variable "public_node_port_to" {
+  description = "End port for public node ingress (UDP)"
+  type        = number
+  default     = 8000
+}

--- a/infra/terraform/modules/eks/main.tf
+++ b/infra/terraform/modules/eks/main.tf
@@ -1,0 +1,196 @@
+# EKS Cluster IAM Role
+resource "aws_iam_role" "cluster" {
+  name = "${var.project_name}-eks-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "eks.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+# EKS Cluster
+resource "aws_eks_cluster" "main" {
+  name     = "${var.project_name}-cluster"
+  role_arn = aws_iam_role.cluster.arn
+  version  = var.kubernetes_version
+
+  vpc_config {
+    subnet_ids              = var.subnet_ids
+    endpoint_private_access = true
+    endpoint_public_access  = true
+    security_group_ids      = [var.cluster_security_group_id]
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster_policy
+  ]
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-cluster"
+    }
+  )
+}
+
+# Node Group IAM Role
+resource "aws_iam_role" "node_group" {
+  name = "${var.project_name}-eks-node-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "node_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "cni_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_group.name
+}
+
+# Launch Template for Private Node Group
+resource "aws_launch_template" "private" {
+  name = "${var.project_name}-private-node-lt"
+
+  instance_type          = var.node_instance_types[0]
+  vpc_security_group_ids = [var.private_node_security_group_id]
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(
+      var.tags,
+      {
+        Name = "${var.project_name}-private-node"
+      }
+    )
+  }
+
+  tags = var.tags
+}
+
+# Launch Template for Public Node Group
+resource "aws_launch_template" "public" {
+  name = "${var.project_name}-public-node-lt"
+
+  instance_type          = var.node_instance_types[0]
+  vpc_security_group_ids = [var.public_node_security_group_id]
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(
+      var.tags,
+      {
+        Name = "${var.project_name}-public-node"
+      }
+    )
+  }
+
+  tags = var.tags
+}
+
+# EKS Node Group - Private Subnet
+resource "aws_eks_node_group" "private" {
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = "${var.project_name}-private-node-group"
+  node_role_arn   = aws_iam_role.node_group.arn
+  subnet_ids      = var.private_subnet_ids
+
+  capacity_type = var.capacity_type
+
+  launch_template {
+    id      = aws_launch_template.private.id
+    version = aws_launch_template.private.latest_version
+  }
+
+  scaling_config {
+    desired_size = var.private_node_desired_size
+    max_size     = var.private_node_max_size
+    min_size     = var.private_node_min_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_policy,
+    aws_iam_role_policy_attachment.cni_policy,
+    aws_iam_role_policy_attachment.ecr_policy,
+  ]
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-private-node-group"
+    }
+  )
+}
+
+# EKS Node Group - Public Subnet
+resource "aws_eks_node_group" "public" {
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = "${var.project_name}-public-node-group"
+  node_role_arn   = aws_iam_role.node_group.arn
+  subnet_ids      = var.public_subnet_ids
+
+  capacity_type = var.capacity_type
+
+  launch_template {
+    id      = aws_launch_template.public.id
+    version = aws_launch_template.public.latest_version
+  }
+
+  scaling_config {
+    desired_size = var.public_node_desired_size
+    max_size     = var.public_node_max_size
+    min_size     = var.public_node_min_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_policy,
+    aws_iam_role_policy_attachment.cni_policy,
+    aws_iam_role_policy_attachment.ecr_policy,
+  ]
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-public-node-group"
+    }
+  )
+}

--- a/infra/terraform/modules/eks/outputs.tf
+++ b/infra/terraform/modules/eks/outputs.tf
@@ -1,0 +1,34 @@
+output "cluster_id" {
+  description = "EKS cluster ID"
+  value       = aws_eks_cluster.main.id
+}
+
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = aws_eks_cluster.main.name
+}
+
+output "cluster_endpoint" {
+  description = "EKS cluster endpoint"
+  value       = aws_eks_cluster.main.endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  description = "EKS cluster certificate authority data"
+  value       = aws_eks_cluster.main.certificate_authority[0].data
+}
+
+output "private_node_group_id" {
+  description = "EKS private node group ID"
+  value       = aws_eks_node_group.private.id
+}
+
+output "public_node_group_id" {
+  description = "EKS public node group ID"
+  value       = aws_eks_node_group.public.id
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "EKS cluster OIDC issuer URL"
+  value       = aws_eks_cluster.main.identity[0].oidc[0].issuer
+}

--- a/infra/terraform/modules/eks/variables.tf
+++ b/infra/terraform/modules/eks/variables.tf
@@ -1,0 +1,101 @@
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "cluster_security_group_id" {
+  description = "Security group ID for EKS cluster"
+  type        = string
+}
+
+variable "private_node_security_group_id" {
+  description = "Security group ID for private node group"
+  type        = string
+}
+
+variable "public_node_security_group_id" {
+  description = "Security group ID for public node group"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for EKS cluster (control plane)"
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for EKS node group"
+  type        = list(string)
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs for EKS node group"
+  type        = list(string)
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version"
+  type        = string
+  default     = "1.29"
+}
+
+variable "node_instance_types" {
+  description = "Instance types for node group"
+  type        = list(string)
+  default     = ["t3.medium"]
+}
+
+variable "capacity_type" {
+  description = "Capacity type for node group (ON_DEMAND or SPOT)"
+  type        = string
+  default     = "ON_DEMAND"
+}
+
+# Private node group scaling
+variable "private_node_desired_size" {
+  description = "Desired number of private nodes"
+  type        = number
+  default     = 2
+}
+
+variable "private_node_min_size" {
+  description = "Minimum number of private nodes"
+  type        = number
+  default     = 1
+}
+
+variable "private_node_max_size" {
+  description = "Maximum number of private nodes"
+  type        = number
+  default     = 3
+}
+
+# Public node group scaling
+variable "public_node_desired_size" {
+  description = "Desired number of public nodes"
+  type        = number
+  default     = 2
+}
+
+variable "public_node_min_size" {
+  description = "Minimum number of public nodes"
+  type        = number
+  default     = 1
+}
+
+variable "public_node_max_size" {
+  description = "Maximum number of public nodes"
+  type        = number
+  default     = 3
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/security_group/main.tf
+++ b/infra/terraform/modules/security_group/main.tf
@@ -1,0 +1,145 @@
+# EKS Cluster Security Group
+resource "aws_security_group" "eks_cluster" {
+  name        = "${var.project_name}-eks-cluster-sg"
+  description = "Security group for EKS cluster"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-eks-cluster-sg"
+    }
+  )
+}
+
+# Private Node Group Security Group
+resource "aws_security_group" "eks_private_node" {
+  name        = "${var.project_name}-eks-private-node-sg"
+  description = "Security group for EKS private node group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "Allow cluster to communicate with nodes"
+    from_port       = 0
+    to_port         = 65535
+    protocol        = "tcp"
+    security_groups = [aws_security_group.eks_cluster.id]
+  }
+
+  ingress {
+    description = "Allow private nodes to communicate with each other"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "-1"
+    self        = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-eks-private-node-sg"
+    }
+  )
+}
+
+# Public Node Group Security Group
+resource "aws_security_group" "eks_public_node" {
+  name        = "${var.project_name}-eks-public-node-sg"
+  description = "Security group for EKS public node group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "Allow cluster to communicate with nodes"
+    from_port       = 0
+    to_port         = 65535
+    protocol        = "tcp"
+    security_groups = [aws_security_group.eks_cluster.id]
+  }
+
+  ingress {
+    description = "Allow public nodes to communicate with each other"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "-1"
+    self        = true
+  }
+
+  ingress {
+    description = "Allow application ports from internet (UDP)"
+    from_port   = var.public_node_port_from
+    to_port     = var.public_node_port_to
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-eks-public-node-sg"
+    }
+  )
+}
+
+# Allow private and public nodes to communicate with each other
+resource "aws_security_group_rule" "private_to_public" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.eks_private_node.id
+  source_security_group_id = aws_security_group.eks_public_node.id
+  description              = "Allow public nodes to communicate with private nodes"
+}
+
+resource "aws_security_group_rule" "public_to_private" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.eks_public_node.id
+  source_security_group_id = aws_security_group.eks_private_node.id
+  description              = "Allow private nodes to communicate with public nodes"
+}
+
+# Allow cluster to receive from private nodes
+resource "aws_security_group_rule" "cluster_from_private_nodes" {
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster.id
+  source_security_group_id = aws_security_group.eks_private_node.id
+  description              = "Allow private nodes to communicate with cluster API"
+}
+
+# Allow cluster to receive from public nodes
+resource "aws_security_group_rule" "cluster_from_public_nodes" {
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster.id
+  source_security_group_id = aws_security_group.eks_public_node.id
+  description              = "Allow public nodes to communicate with cluster API"
+}

--- a/infra/terraform/modules/security_group/outputs.tf
+++ b/infra/terraform/modules/security_group/outputs.tf
@@ -1,0 +1,14 @@
+output "eks_cluster_security_group_id" {
+  description = "EKS cluster security group ID"
+  value       = aws_security_group.eks_cluster.id
+}
+
+output "eks_private_node_security_group_id" {
+  description = "EKS private node security group ID"
+  value       = aws_security_group.eks_private_node.id
+}
+
+output "eks_public_node_security_group_id" {
+  description = "EKS public node security group ID"
+  value       = aws_security_group.eks_public_node.id
+}

--- a/infra/terraform/modules/security_group/variables.tf
+++ b/infra/terraform/modules/security_group/variables.tf
@@ -1,0 +1,27 @@
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "public_node_port_from" {
+  description = "Start port for public node ingress"
+  type        = number
+  default     = 7000
+}
+
+variable "public_node_port_to" {
+  description = "End port for public node ingress"
+  type        = number
+  default     = 8000
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- EKSモジュールを追加（private/publicノードグループ対応）
- security_groupモジュールを追加（cluster, private_node, public_node用SG）
- environments/eksを追加（EKSデプロイ用）
- コスト削減のためSPOTインスタンス対応
- publicノード用にUDP 7000-8000ポートを許可

## 構成
```
modules/
├── security_group/   # SG定義
└── eks/              # EKSクラスター、ノードグループ

environments/
└── eks/              # EKS環境
```

## Test plan
- [ ] `terraform init` が成功すること
- [ ] `terraform plan` でエラーがないこと
- [ ] EKSクラスターが正常に作成されること
- [ ] private/publicノードグループが正常に起動すること

🤖 Generated with [Claude Code](https://claude.ai/code)